### PR TITLE
Refactor methods throughout files, rewrite board render test

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -32,19 +32,19 @@ class Board
 
   def valid_order_and_diagonal?(coord1, coord2)
     new_coords = []
-    if coord1[1] == coord2[1]
+    if coord1[1..-1] == coord2[1..-1]
       letters = (coord1[0]..coord2[0]).to_a
-      letters.each {|letter| new_coords << letter + coord1[1]}
+      letters.each {|letter| new_coords << letter + coord1[1..-1]}
     elsif coord1[0] == coord2[0]
-      numbers = (coord1[1]..coord2[1]).to_a
+      numbers = (coord1[1..-1]..coord2[1..-1]).to_a
       numbers.each {|num| new_coords << coord1[0] + num}
     end
     new_coords
   end
 
   def valid_overlapping?(coords)
-    coords.each do |coord|
-      return false if @cells[coord].empty? != true
+    coords.all? do |coord|
+      @cells[coord].empty?
     end
   end
 
@@ -62,12 +62,15 @@ class Board
     board = "  "
     @numbers.each do |number|
       board += "#{number} "
+      if number.digits.count < 2
+        board += " "
+      end
     end
     board += "\n"
     @letters.each do |letter|
       board += letter
         @numbers.each do |number|
-          board += " #{@cells["#{letter}#{number}"].render(default)}"
+          board += " #{@cells["#{letter}#{number}"].render(default)} "
         end
       board += "\n"
     end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -26,10 +26,10 @@ class Cell
   end
 
   def render(default=false)
-    return "S" if default == true && !empty? && !fired_upon?
     return "X" if !empty? && @ship.sunk?
     return "M" if fired_upon? && empty?
     return "H" if fired_upon? && !empty?
+    return "S" if default == true && !empty?
     return "." if !fired_upon?
   end
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -3,7 +3,7 @@ require './lib/cell'
 require './lib/ship'
 
 class Game
-  attr_reader :player_board, :ai_board, :player_ships, :ai_dup_cells
+  attr_reader :player_board, :ai_board, :player_ships 
 
   def initialize
     @player_board = Board.new

--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -8,7 +8,7 @@ class Ship
   end
 
   def sunk?
-    @health == 0
+    @health.zero?
   end
 
   def hit

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -62,20 +62,20 @@ class BoardTest < Minitest::Test
   end
 
   def test_render_method
-    test_board = "  1 2 3 4 \nA . . . .\nB . . . .\nC . . . .\nD . . . .\n"
+    test_board = "  1  2  3  4  \nA .  .  .  . \nB .  .  .  . \nC .  .  .  . \nD .  .  .  . \n"
     assert_equal test_board, @board.render
     @board.place(@cruiser, ["A1", "A2", "A3"])
-    test_board_true = "  1 2 3 4 \nA S S S .\nB . . . .\nC . . . .\nD . . . .\n"
+    test_board_true = "  1  2  3  4  \nA S  S  S  . \nB .  .  .  . \nC .  .  .  . \nD .  .  .  . \n"
     assert_equal test_board_true, @board.render(true)
     @board.cells["B1"].fire_upon
-    test_board_hit = "  1 2 3 4 \nA S S S .\nB M . . .\nC . . . .\nD . . . .\n"
+    test_board_hit = "  1  2  3  4  \nA S  S  S  . \nB M  .  .  . \nC .  .  .  . \nD .  .  .  . \n"
     assert_equal test_board_hit, @board.render(true)
     @board.cells["A1"].fire_upon
-    test_board_ship_hit = "  1 2 3 4 \nA H S S .\nB M . . .\nC . . . .\nD . . . .\n"
+    test_board_ship_hit = "  1  2  3  4  \nA H  S  S  . \nB M  .  .  . \nC .  .  .  . \nD .  .  .  . \n"
     assert_equal test_board_ship_hit, @board.render(true)
     @board.cells["A2"].fire_upon
     @board.cells["A3"].fire_upon
-    test_board_ship_sunk = "  1 2 3 4 \nA X X X .\nB M . . .\nC . . . .\nD . . . .\n"
+    test_board_ship_sunk = "  1  2  3  4  \nA X  X  X  . \nB M  .  .  . \nC .  .  .  . \nD .  .  .  . \n"
     assert_equal test_board_ship_sunk, @board.render(true)
   end
 end


### PR DESCRIPTION
This commit:
-Changes placement validation to work with coordinates with double-digit numbers (e.g. "A23" or "B12")
-Changes board rendering and test for the same reason (numbers became misaligned when in double digits)
-Simplifies `valid_overlapping?` method in board
-Moves "S" down in precedence in cell `render` method to eliminate third conditional
-Changes ship `sunk?` to use `.zero?` instead of `== 0`
